### PR TITLE
chore: Update configuration to be ESLint 1.0.0 compatible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -135,7 +135,6 @@
 		"no-proto": [2],
 		"no-redeclare": [2],
 		"no-regex-spaces": [2],
-		"no-reserved-keys": [2],
 		"no-restricted-modules": [0],
 		"no-return-assign": [2, "always"],
 		"no-script-url": [2],


### PR DESCRIPTION
In the 1.0.0 release ESLint merged two rules.

`Breaking: merge no-reserved-keys into quote-props (fixes #1539)`

The removed rule was enabled in the ESLint config.
It doesn't appear as if the same behaviour as before can be
enforced with the remaining rule. So leaving `quote-props` disabled.

Further details http://eslint.org/blog/2015/07/eslint-1.0.0-released/#breaking-changes-100
