### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/ljharb/eslint-config.git"
+		"url": "git+https://github.com/ljharb/eslint-config.git"
 	},
 	"keywords": [
 		"eslint",


### PR DESCRIPTION
## Summary

- update the npm package repository metadata from the deprecated `git://` protocol to a GitHub HTTPS URL

## Validation

- parsed `package.json` and confirmed `repository.url` is `git+https://github.com/ljharb/eslint-config.git`
- ran `npm pack --dry-run --ignore-scripts --json`
  - npm warned that no `.npmignore` was present and used `.gitignore`; this command intentionally skipped scripts for a metadata-only dry run
- ran `git diff --check`
