### PR TITLE
chore: use public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/ljharb/eslint-config.git"
+		"url": "git+https://github.com/ljharb/eslint-config.git"
 	},
 	"keywords": [
 		"eslint",


### PR DESCRIPTION
## Summary
- update the package `repository.url` metadata from the legacy `git://` GitHub URL to a public `git+https` URL
- leave runtime code, dependencies, package version, exports, and package contents unchanged

## Why
The npm metadata currently points at the unauthenticated `git://` protocol. GitHub's HTTPS URL is the more broadly supported public repository URL for package metadata and automated tooling.

## Validation
- `npm view @ljharb/eslint-config repository homepage bugs --json`
- metadata assertion confirming only `repository.url` changed in `package.json`
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm run lint` (completed; existing `func-style` warning in `flat.mjs` remains a warning)
- `npm run tests-only` (7/7 tests passed in a `/tmp` path without spaces; the same test command in my workspace path hit an ESLint path-splitting issue because the parent directory contains a space)
- `npm pack --dry-run --ignore-scripts --json .` (57 files)
- `git diff --check`
